### PR TITLE
Examples for Shapes and PropertyShapes + Restore of complete configuration files

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -1,25 +1,55 @@
+# ---------------------------------- QSE Config -----------------------------
+qse_exact_file=true
+qse_exact_query_based=false
+qse_approximate_file=false
+qse_approximate_query_based=false
+qse_approximate_parallel_query_based=false
+qse_approximate_parallel_qb_threads=1
 
-# ---------------------------------- Paths Config (Must be set correctly by user) -----------------------------
+# Please specify the list of classes in file available at //app/qse/config/pruning/classes.txt
+qse_specific_classes=falsemax_cardinality=true
+min_cardinality=true
 
-dataset_path=/Users/John/Documents/GitHub/data/CityDBpedia.nt
-resources_path=/Users/John/Documents/GitHub/qse/src/main/resources
-output_file_path=/Users/John/Documents/GitHub/qse/Output/TEMP/
+# ---------------------------------- Dataset Config -----------------------------
+dataset_name=DATASET
+expected_number_classes=15
+expected_number_of_lines=1000000
+is_wikidata=false
+# set true to add examples to shapes
+add_examples=true
+# predicates used for labels (separated by ",")
+label_properties=<http://www.w3.org/2000/01/rdf-schema#label>,<http://www.w3.org/2004/02/skos/core#prefLabel>
+# IRI used for examples in shapes
+example_IRI=http://example.org/example
 
 
-# ---------------------------------- Default QSE Config (User can update as per requirement)-----------------------------
 
-expected_number_classes=100
-expected_number_of_lines=10000000
 
-#  If set to true, then please specify the list of classes in file available at /qse/config/pruning/classes.txt and correct the path for config_dir_path parameter below
-qse_specific_classes=false
-config_dir_path=/Users/John/Documents/GitHub/qse/config/
+# ---------------------------------- GraphDB Endpoint Config - For QSE (Query-based) -----------------------------
+graphdb_url=http://graphdb.srver.com:7200
+graphdb_repository=REPOSITORY
 
-# default instance type property is rdf:type
-instance_type_property=<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
 
-# enable this if your graph is WikiData
-#instance_type_property=<http://www.wikidata.org/prop/direct/P31>
+# ---------------------------------- Sampling Parameters - For QSE Approximate -----------------------------
+entity_sampling_threshold=100
+entity_sampling_target_percentage=75
+
+
+# ---------------------------------- Validation -----------------------------
+qse_validation=false
+# extract shapes using shacl not for validation purpose
+qse_validation_with_shNot=false
+
+
+# ---------------------------------- Paths Config -----------------------------
+dataset_path=/app/data/lubm.n3
+resources_path=/app/local/src/main/resources
+
+config_dir_path=/app/local/config/
+output_file_path=/app/local/Output/lubm/default/
+default_directory=/app/local/Output/lubm/default/
+validation_input_dir=/app/local/validation/
+
 
 # annotate shapes with support and confidence
 annotateSupportConfidence=true
@@ -27,4 +57,4 @@ annotateSupportConfidence=true
 # ---------------------------------- Pruning Thresholds (Support and Confidence) -----------------------------
 
 # 1st parameter is confidence and 2nd is support. So for more parameters, you can append the list with more pairs lie (0.25,150) etc. Please do not use spaces in this list.
-pruning_thresholds={(0.1,100),(0.2,200)}
+pruning_thresholds={(0.1,100)}

--- a/src/main/java/cs/Main.java
+++ b/src/main/java/cs/Main.java
@@ -12,7 +12,11 @@ import cs.utils.Constants;
 import cs.utils.FilesUtil;
 import cs.utils.Utils;
 import cs.validation.QseSHACLValidator;
+import org.apache.jena.base.Sys;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Main {
     public static String configPath;
@@ -26,15 +30,24 @@ public class Main {
     public static boolean extractMaxCardConstraints;
     public static boolean isWikiData;
     public static boolean qseFromSpecificClasses;
+    /** Indicates whether or not to extend the generated shapes with examples **/
+    public static boolean addExamples;
+    /** List of all predicates used to identify labels **/
+    public static List<String> labelProperties;
+    /** IRI used as predicate to indicate examples in Shapes and PropertyShapes **/
+    public static String exampleIRI;
+
+
     
     public static void main(String[] args) throws Exception {
         configPath = args[0];
         Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.INFO);
-        qseExactExecutionWithMinimumParams();
-        
-        //readConfig();
-        //benchmark();
+        //qseExactExecutionWithMinimumParams();
+
+        // N.B. de-commented to use complete configuration files
+        readConfig();
+        benchmark();
         //new PrecisionRecallComputer();
     }
     
@@ -50,30 +63,51 @@ public class Main {
             }
             
             if (isActivated("qse_exact_file")) {
-                Parser parser = new Parser(datasetPath, numberOfClasses, numberOfInstances, typeProperty);
+                Parser parser = new Parser(datasetPath, numberOfClasses, numberOfInstances, typeProperty, addExamples, labelProperties);
                 parser.run();
             }
             
             if (isActivated("qse_approximate_file")) {
-                ReservoirSamplingParser reservoirSamplingParser = new ReservoirSamplingParser(datasetPath, numberOfClasses, numberOfInstances, typeProperty, entitySamplingThreshold);
+                ReservoirSamplingParser reservoirSamplingParser = new ReservoirSamplingParser(datasetPath, numberOfClasses, numberOfInstances, typeProperty, addExamples, labelProperties, entitySamplingThreshold);
                 reservoirSamplingParser.run();
             }
-            
+
+
             if (isActivated("qse_exact_query_based")) {
-                QbParser qbParser = new QbParser(typeProperty);
-                qbParser.run();
+                // Can't add examples with query-based parsers TODO add examples with query-based parsers
+                if (!addExamples) {
+                    QbParser qbParser = new QbParser(typeProperty);
+                    qbParser.run();
+                }
+                else {
+                    System.err.println("ERROR: cannot add examples with a query-based parser. Please disable 'add_examples' property in your properties file");
+                }
             }
-            
+
             if (isActivated("qse_approximate_query_based")) {
-                QbSampling qbSampling = new QbSampling(numberOfClasses, numberOfInstances, typeProperty, entitySamplingThreshold);
-                qbSampling.run();
+                // Can't add examples with query-based parsers TODO add examples with query-based parsers
+                if (!addExamples) {
+                    QbSampling qbSampling = new QbSampling(numberOfClasses, numberOfInstances, typeProperty, entitySamplingThreshold);
+                    qbSampling.run();
+                }
+                else {
+                    System.err.println("ERROR: cannot add examples with a query-based parser. Please disable 'add_examples' property in your properties file");
+                }
             }
-            
+
             if (isActivated("qse_approximate_parallel_query_based")) {
-                int numOfThreads = Integer.parseInt(paramVal("qse_approximate_parallel_qb_threads"));
-                ParallelQbSampling parallelQbSampling = new ParallelQbSampling(numberOfClasses, numberOfInstances, typeProperty, entitySamplingThreshold, numOfThreads);
-                parallelQbSampling.run();
+                // Can't add examples with query-based parsers TODO add examples with query-based parsers
+                if (!addExamples) {
+                    int numOfThreads = Integer.parseInt(paramVal("qse_approximate_parallel_qb_threads"));
+                    ParallelQbSampling parallelQbSampling = new ParallelQbSampling(numberOfClasses, numberOfInstances, typeProperty, entitySamplingThreshold, numOfThreads);
+                    parallelQbSampling.run();
+                }
+                else {
+                    System.err.println("ERROR: cannot add examples with a query-based parser. Please disable 'add_examples' property in your properties file");
+                }
             }
+
+
             if (isActivated("qse_validation")) {
                 new QseSHACLValidator(true);
             }
@@ -96,6 +130,10 @@ public class Main {
         entitySamplingTargetPercentage = Integer.parseInt(paramVal("entity_sampling_target_percentage"));
         qseFromSpecificClasses = isActivated("qse_specific_classes");
         outputFilePath = paramVal("output_file_path");
+        addExamples = isActivated("add_examples");
+        exampleIRI = paramVal("example_IRI");
+        // Read all possible predicates used for labels
+        labelProperties = readLabelProperties();
     }
     
     private static void qseExactExecutionWithMinimumParams() {
@@ -107,13 +145,34 @@ public class Main {
         isWikiData = false;
         qseFromSpecificClasses = isActivated("qse_specific_classes");
         outputFilePath = paramVal("output_file_path");
-        
+        addExamples = isActivated("add_examples");
+        exampleIRI = paramVal("example_IRI");
+        // Read all possible predicates used for labels
+        labelProperties = readLabelProperties();
+
         // Run QSE-Exact
-        Parser parser = new Parser(datasetPath, numberOfClasses, numberOfInstances, paramVal("instance_type_property"));
+        Parser parser = new Parser(datasetPath, numberOfClasses, numberOfInstances, paramVal("instance_type_property"), addExamples, labelProperties);
         parser.run();
     }
     
     private static boolean isActivated(String option) {return Boolean.parseBoolean(ConfigManager.getProperty(option));}
     
     private static String paramVal(String prop) {return ConfigManager.getProperty(prop);}
+
+    // Read all possible predicates used to identify labels
+    private static List<String> readLabelProperties() {
+        // Reading raw property value
+        String rawLabelProperties = paramVal("label_properties");
+        List<String> labelProperties;
+        if (rawLabelProperties != null) {
+            // Separating single predicates contained in the raw string
+            labelProperties = new ArrayList<>(List.of(rawLabelProperties.split(",")));
+        }
+        else {
+            labelProperties = new ArrayList<>();
+        }
+
+        return labelProperties;
+    }
+    /*-------------------------------------------------------------------*/
 }

--- a/src/main/java/cs/qse/common/EntityData.java
+++ b/src/main/java/cs/qse/common/EntityData.java
@@ -10,7 +10,8 @@ import java.util.*;
 public class EntityData {
     Set<Integer> classTypes; // O(T) number of types of this node
     public Map<Integer, PropertyData> propertyConstraintsMap; // Map from PropertyID -> PropertyData which consists of property's object types and count
-    
+
+
     public EntityData() {
         this.classTypes = new HashSet<>();
         this.propertyConstraintsMap = new HashMap<>();

--- a/src/main/java/cs/qse/common/ExampleManager.java
+++ b/src/main/java/cs/qse/common/ExampleManager.java
@@ -1,0 +1,997 @@
+package cs.qse.common;
+
+import cs.Main;
+import cs.qse.common.encoders.Encoder;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.rio.helpers.NTriplesUtil;
+import org.semanticweb.yars.nx.Node;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+
+public class ExampleManager {
+
+    /** Maximum number of examples per class **/
+    public static final int EXAMPLES_FOR_CLASS = 5;
+    /** Maximum number of examples per property (of a specific class) **/
+    public static final int EXAMPLES_FOR_PROPERTY = 5;
+    /** Default min-value of a property cardinality **/
+    public static final int DEFAULT_MIN = 0;
+    /** Default max-value of a property cardinality **/
+    public static final int DEFAULT_MAX = Integer.MAX_VALUE;
+    /** Default encoded property type **/
+    public static final int DEFAULT_ENCODED_PROP_TYPE = -1;
+    /** Default label of a property **/
+    public static final String DEFAULT_LABEL = " ";
+    /** IRI used as predicate to denote examples in Shapes and PropertyShapes **/
+    public static IRI EXAMPLE_IRI = Values.getValueFactory().createIRI("http://example.org/example");
+
+
+    /** For each class we save a bunch of data **/
+    Map<Integer,ClassExampleData> classToExData;
+
+    /**
+     * List of ALL example-nodes of ALL classes with their data.<br>
+     * N.B. Each couple (key,value) stored in this object is the SAME one stored in his corresponding map in [classToExData].
+     *      So, all objects stored in this map ARE ONLY REFERENCES to real objects stored in the maps [classToExData/exNodeToExData]
+     */
+    Map<Node,ExampleNodeData> exNodeToExData;
+
+    /**
+     * Set of ALL properties, independently of the class.<br>
+     * N.B. All objects stored in this set ARE ONLY REFERENCES to real objects stored in the maps [classToExData/propToExData]
+     */
+    Set<Integer> encodedProperties;
+
+    /**
+     * Set of ALL values of ALL properties (even property-values of example-nodes).<br>
+     * N.B. All objects stored in this set ARE ONLY REFERENCES to real objects stored in the sets [classToExData/propToExData/encodedValues]
+     */
+    Set<PropertyValue> encodedPropertiesValues;
+
+    /** For each class, property, example-node and property-value we save his label (if there is one)**/
+    Map<Integer, Integer> IRItoLabel;
+
+    /**
+     * Encoder used to encode/decode strings.<br>
+     * N.B. This has to be the same encoder used in the parser!
+     */
+    Encoder stringEncoder;
+
+
+    public ExampleManager(Encoder stringEncoder){
+        classToExData = new HashMap<>();
+        exNodeToExData = new HashMap<>();
+        encodedProperties = new HashSet<>();
+        encodedPropertiesValues = new HashSet<>();
+        IRItoLabel = new HashMap<>();
+        this.stringEncoder = stringEncoder;
+        // Use the exampleIRI of the config-file if there is one
+        if (Main.exampleIRI != null) {
+            EXAMPLE_IRI = Values.getValueFactory().createIRI(Main.exampleIRI);
+        }
+    }
+
+
+
+    /*=============================Metodi per la gestione dei nodi di esempio=============================*/
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @return The number of example-nodes stored for the class {@code encodedClassIRI}.
+     */
+    public int exampleNodeCount(Integer encodedClassIRI){
+        if (classToExData.get(encodedClassIRI) == null)
+            return 0;
+
+        return classToExData.get(encodedClassIRI).exNodeToExData.size();
+    }
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @return The total number of nodes (of class {@code encodedClassIRI}) seen so far
+     */
+    public int totalNodeCount(Integer encodedClassIRI){
+        if (classToExData.get(encodedClassIRI) == null)
+            return 0;
+
+        return classToExData.get(encodedClassIRI).getTotalNodeCount();
+    }
+
+    /**
+     * Add {@code exNode} to the example-nodes of the class {@code encodedClassIRI}.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param exNode The example-node we want to add for {@code encodedClassIRI}
+     */
+    public void addExampleNode(Integer encodedClassIRI, Node exNode){
+        // If no example-node has been added to the class yet, initialize the example-node list of the class
+        if (!classToExData.containsKey(encodedClassIRI)){
+            classToExData.put(encodedClassIRI, new ClassExampleData());
+        }
+
+        ExampleNodeData nodeData = new ExampleNodeData();
+        // Adding the example-node to the class example-nodes
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.addExampleNode(exNode, nodeData);
+    }
+
+    /**
+     * IMPLEMENTS RESERVOIR SAMPLING ON EXAMPLE-NODES.<br>
+     * If {@code candidateIndex} < {@code EXAMPLES_FOR_CLASS}, then replace node of index {@code candidateIndex} with the new example-node {@code exNode}
+     * @param candidateIndex Index of the example-node that could be replaced
+     * @param encodedClassIRI Encoded IRI of the class
+     * @param exNode New exampleNode
+     **/
+    public void replaceExampleNode(int candidateIndex, Integer encodedClassIRI, Node exNode){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        Set<Node> classNodes = classData.exNodeToExData.keySet();
+
+        // With a probability of EXAMPLES_FOR_CLASS/totalNodeCount, we add the new node removing an old one
+        if (candidateIndex < EXAMPLES_FOR_CLASS){
+            /* Adding the new node ONLY IF it's not already in the set.
+             If we don't check this, we would delete the candidate-node without adding the new node. This would happen because
+             if the new node is already in the set, it won't be added(since a set can't contain the same node twice).
+             So we would have one less example-node!*/
+            if (!classNodes.contains(exNode)) {
+                // Removing the candidate node
+                classData.removeExampleNode(candidateIndex);
+                // Adding the new example-node
+                addExampleNode(encodedClassIRI, exNode);
+            }
+        }
+        // If the "dice roll" is not good, just increment the number of nodes seen so far
+        else{
+            classData.incrementTotalNodeCount();
+        }
+    }
+
+    /**
+     * Copy the references of ALL example-nodes of ALL classes into {@code exNodeToExData}
+     */
+    public void listExampleNodes(){
+        classToExData.forEach((encodedClassIRI, classData) -> {
+            /* N.B. In [exNodeToExData] we copy ONLY the references of the objects [classData.exNodeToExData] (no new objects are created).
+             In this way, updating the data in one map automatically updates the data in the other.*/
+            exNodeToExData.putAll(classData.exNodeToExData);
+        });
+    }
+
+    /**
+     * @param exNode Node to check for presence among the example-nodes.
+     * @return {@code true} if {@code exNode} is an example-node of any class. <br>
+     *         {@code false} otherwise.
+     */
+    public boolean isExampleNode(Node exNode){
+        return exNodeToExData.containsKey(exNode);
+    }
+
+    /**
+     * Add {@code encodedProperty} to {@code exNode} properties and store {@code encodedValue} as its example-value. <br>
+     * If {@code encodedProperty} is already a {@code exNode} property, store {@code encodedValue} as another example-value
+     * @param exNode Example node
+     * @param encodedProperty Encoded property of {@code exNode}
+     * @param encodedActualValue Encoded value of the property
+     * @param encodedRawValue Encoded raw-value of the property
+     */
+    public void addNodeData(Node exNode, Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+        ExampleNodeData nodeData = exNodeToExData.get(exNode);
+        nodeData.addPropertyValue(encodedProperty, encodedActualValue, encodedRawValue);
+    }
+    /*=====================================================================================================*/
+
+
+
+
+
+    /*===============================Metodi per la gestione delle proprietà===============================*/
+    /**
+     * Store {@code encodedProperty} in the list of all properties({@code encodedProperties})
+     * @param encodedProperty Encoded property to store
+     */
+    public void storeProperty(Integer encodedProperty){
+        encodedProperties.add(encodedProperty);
+    }
+
+    /**
+     * @param encodedProperty Encoded property to check for
+     * @return {@code true} if {@code encodedProperty} is stored(it appears in {@code encodedProperties}). <br>
+     *          {@code false} otherwise
+     */
+    public boolean isProperty(Integer encodedProperty){
+        return encodedProperties.contains(encodedProperty);
+    }
+
+    /**
+     * Copy the references of ALL example-values of ALL properties of ALL classes into {@code encodedPropertiesValues}
+     */
+    public void listPropertiesValues(){
+        classToExData.forEach((encodedClassIRI, classData) -> {
+            classData.propToExData.forEach((encodedProperty, propertyData) -> {
+                /* N.B. Into [encodedPropertiesValues] we copy ONLY THE REFERENCES to the [encodedValues]. So no new objects are created */
+                encodedPropertiesValues.addAll(propertyData.encodedValues);
+            });
+        });
+
+    }
+
+    /**
+     * @param encodedActualValue Encoded value
+     * @param encodedRawValue Encoded raw-value
+     * @return {@code true} if the couple ({@code encodedActualValue},{@code encodedRawValue}) is stored(it appears in {@code encodedPropertiesValues}). <br>
+     *          {@code false} otherwise.
+     */
+    public boolean isPropertyValue(Integer encodedActualValue, Integer encodedRawValue){
+        PropertyValue totalValue = new PropertyValue(encodedActualValue, encodedRawValue);
+        return encodedPropertiesValues.contains(totalValue);
+    }
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @return The current number of example-values stored for the property {@code encodedProperty} in class {@code encodedClassIRI}
+     */
+    public int propertyValuesCount(Integer encodedClassIRI, Integer encodedProperty){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        return classData.propertyValuesCount(encodedProperty);
+    }
+
+    /**
+     * Add the couple ({@code encodedActualValue}, {@code encodedRawValue}) to the example-values of the property {@code encodedProperty} in class {@code encodedClassIRI}
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param encodedActualValue Encoded value.
+     * @param encodedRawValue Encoded raw-value.
+     */
+    public void addPropertyExample(Integer encodedClassIRI, Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.addPropertyExample(encodedProperty, encodedActualValue, encodedRawValue);
+        // Keeping track of all properties
+        storeProperty(encodedProperty);
+    }
+
+    /**
+     * IMPLEMENTS RESERVOIR SAMPLING FOR EXAMPLE-VALUES OF A PROPERTY. <br>
+     * If {@code candidateIndex} < {@code EXAMPLES_FOR_PROPERTY}, then replace value of index {@code candidateIndex} with the new example-value ({@code encodedActualValue}, {@code encodedRawValue}).
+     * @param candidateIndex Index of the example-value that could be replaced.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param encodedActualValue Encoded value.
+     * @param encodedRawValue Encoded raw-value.
+     **/
+    public void replacePropertyExample(int candidateIndex, Integer encodedClassIRI, Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+
+        // With a probability of EXAMPLES_FOR_PROPERTY/totalValueCount, we add the new value removing an old one
+        if (candidateIndex < EXAMPLES_FOR_PROPERTY){
+            /* Adding the new value ONLY IF it's not already in the set.
+             If we don't check this, we would delete the candidate-value without adding the new one. This would happen because
+             if the new value is already in the set, it won't be added(since a set can't contain the same value twice).*/
+            if (!classData.propertyContainsValue(encodedProperty, encodedActualValue, encodedRawValue)){
+                // Removing the candidate value
+                classData.removePropertyValue(candidateIndex, encodedProperty);
+                // Adding the new example-value
+                addPropertyExample(encodedClassIRI, encodedProperty, encodedActualValue, encodedRawValue);
+            }
+        }
+        // If the "dice roll" is not good, just increment the number of value seen so far for the property
+        else{
+            classData.incrementPropertyTotaleValueCount(encodedProperty);
+        }
+    }
+
+    /**
+     * Set the minCount of {@code encodedProperty} in class {@code encodedClassIRI} to the given value.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param minCount Given value.
+     */
+    public void setPropertyMinCount(Integer encodedClassIRI, Integer encodedProperty, int minCount){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.setPropertyMinCount(encodedProperty, minCount);
+    }
+
+    /**
+     * Set the maxCount of {@code encodedProperty} in class {@code encodedClassIRI} to the given value.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param maxCount Given value.
+     */
+    public void setPropertyMaxCount(Integer encodedClassIRI, Integer encodedProperty, int maxCount){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.setPropertyMaxCount(encodedProperty, maxCount);
+    }
+
+    /**
+     * Set the propertyType of {@code encodedProperty} in class {@code encodedClassIRI} to the given value.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param encodedPropertyType Encoded given value.
+     */
+    public void setPropertyType(Integer encodedClassIRI, Integer encodedProperty, Integer encodedPropertyType){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.setPropertyType(encodedProperty, encodedPropertyType);
+    }
+
+    /**
+     * Set the isLiteralType of {@code encodedProperty} in class {@code encodedClassIRI} to the given value.
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @param isLiteral Given value.
+     */
+    public void setPropertyIsLiteral(Integer encodedClassIRI, Integer encodedProperty, boolean isLiteral){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        classData.setPropertyIsLiteral(encodedProperty, isLiteral);
+    }
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @return {@code true} if property {@code encodedProperty} in class {@code encodedClassIRI} is a literal-type property.<br>
+     *            {@code false} otherwise.
+     */
+    public boolean isPropertyLiteralType(Integer encodedClassIRI, Integer encodedProperty){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        return classData.isPropertyLiteralType(encodedProperty);
+    }
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property.
+     * @return The total number of values seen so far for the property {@code encodedProperty} in class {@code encodedClassIRI}.
+     */
+    public int totalPropertyValueCount(Integer encodedClassIRI, Integer encodedProperty){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        return classData.getPropertyTotalValueCount(encodedProperty);
+    }
+    /*================================================================================================*/
+
+
+
+    /*===============================Metodi per la gestione delle label===============================*/
+
+    /**
+     * Associate the label {@code encodedLabel} to the subject {@code encodedSubject}.
+     * @param encodedSubject Encoded subject of the label.
+     * @param encodedLabel Encoded label.
+     */
+    public void storeLabel(Integer encodedSubject, Integer encodedLabel){
+        IRItoLabel.put(encodedSubject, encodedLabel);
+    }
+
+    /**
+     * @param encodedSubject Encoded subject to analyze.
+     * @return {@code true} if {@code encodedSubject} represents a class.
+     */
+    public boolean isClass(Integer encodedSubject){
+        return classToExData.containsKey(encodedSubject);
+    }
+    /*================================================================================================*/
+
+
+
+
+    /*================================Metodi per la creazione degli esempi================================*/
+    /**
+     * @param encodedClassIRI Encoded IRI of the class to build the example of.
+     * @return Set of example strings for class {@code encodedClassIRI}.
+     */
+    public Set<String> buildExampleForClass(Integer encodedClassIRI){
+        // Apply no filter to properties
+        Set<Integer> allClassProperties = classToExData.get(encodedClassIRI).propToExData.keySet();
+        return buildExampleForClassWithFilter(encodedClassIRI, allClassProperties);
+    }
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class to build the example of.
+     * @param filteredProperties Set of (encoded)properties that could be used to build example strings.
+     * @return Set of example strings for class {@code encodedClassIRI}. Strings will contain only properties in {@code filteredProperties}
+     */
+    public Set<String> buildExampleForClassWithFilter(Integer encodedClassIRI, Set<Integer> filteredProperties){
+        // Final set of example strings for the given class
+        Set<String> completeExample = new HashSet<>();
+
+        // Iterate over all the class example-nodes and, for each one, build an example string
+        classToExData.get(encodedClassIRI).exNodeToExData.forEach((exNode, nodeData)->{
+            String nodeName = exNode.getLabel();
+            String className = stringEncoder.decode(encodedClassIRI);
+            Integer encodedNodeIRI = stringEncoder.encode(nodeName);
+            // Adding labels of example-node and class (if there are associated labels)
+            if (IRItoLabel.containsKey(encodedNodeIRI))
+                nodeName += "("+stringEncoder.decode(IRItoLabel.get(encodedNodeIRI))+")";
+            else
+                nodeName += "("+DEFAULT_LABEL+")";
+            if (IRItoLabel.containsKey(encodedClassIRI))
+                className += "("+stringEncoder.decode(IRItoLabel.get(encodedClassIRI))+")";
+            else
+                className += "("+DEFAULT_LABEL+")";
+
+
+            StringBuilder exampleString = new StringBuilder();
+            exampleString.append(nodeName).append(" is a ").append(className);
+
+            // Iterate over all the example-node data (properties and property-values)
+            // For each property add the example of that property
+            nodeData.propToExData.forEach((encodedProperty, propertyData) -> {
+                // Adding only properties that belong to the filtered property set
+                if (filteredProperties.contains(encodedProperty)) {
+                    exampleString.append("; has ");
+
+                    // Adding min and max constraints (only if different from min:0, max:INF)
+                    Integer minCount = propertyData.minCount;
+                    Integer maxCount = propertyData.maxCount;
+                    if (!minCount.equals(DEFAULT_MIN))
+                        exampleString.append("at least ").append(minCount).append(" ");
+                    if (!maxCount.equals(DEFAULT_MAX))
+                        exampleString.append("at most ").append(maxCount).append(" ");
+
+                    // Adding property name
+                    exampleString.append( stringEncoder.decode(encodedProperty) );
+                    // Adding property label
+                    if (IRItoLabel.containsKey(encodedProperty)) {
+                        exampleString.append("(")
+                                .append( stringEncoder.decode(IRItoLabel.get(encodedProperty)) )
+                                .append(")");
+                    }
+                    else {
+                        exampleString.append("(").append(DEFAULT_LABEL).append(")");
+                    }
+                }
+            });
+
+            // Adding current example string to the complete set
+            completeExample.add( exampleString.toString() );
+        });
+
+        return completeExample;
+    }
+
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property to build the example of.
+     * @return Set of example-values for property {@code encodedProperty} of class {@code encodedClassIRI}. Values are given as Literals.
+     */
+    public Set<Literal> buildExamplesForLiteralTypeProperty(Integer encodedClassIRI, Integer encodedProperty){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        PropertyExampleData propertyData = classData.propToExData.get(encodedProperty);
+        Set<PropertyValue> encodedValues = null;
+        Integer propertyType = null;
+
+        // Check if there property exists in the class
+        if (propertyData != null){
+           encodedValues = propertyData.encodedValues;
+           propertyType = propertyData.getPropertyType();
+        }
+
+        Set<Literal> examples = new HashSet<>();
+
+        // Check if there is any example-value for the property
+        if (encodedValues != null) {
+            for (PropertyValue enVal : encodedValues) {
+                String rawValue = stringEncoder.decode(enVal.rawValue);
+                Literal literal;
+
+                /* Trying to create the literal for the example-value
+                 N.B. It's important to use the raw-value because it contains the value type (i.e. "30"^^<http://www.w3.org/2001/XMLSchema#int>)
+                      Otherwise the parser wouldn't know which type use to create the Literal*/
+                try {
+                    literal = NTriplesUtil.parseLiteral(rawValue, Values.getValueFactory());
+                }
+                // If the literal creation fails, just create a Literal of type string
+                catch (IllegalArgumentException e) {
+                    System.err.println("Formato N-Triples non valido per il valore: " + rawValue);
+                    literal = Values.literal(rawValue);
+                }
+
+                examples.add(literal);
+            }
+        }
+
+
+
+        return examples;
+    }
+
+
+    /**
+     * @param encodedClassIRI Encoded IRI of the class.
+     * @param encodedProperty Encoded property to build the example of.
+     * @return  Set of example-values for property {@code encodedProperty} of class {@code encodedClassIRI}.
+     *          Values are given as Strings and also contains labels(if there is any).
+     */
+    public Set<String> buildExamplesForNonLiteralTypeProperty(Integer encodedClassIRI, Integer encodedProperty){
+        ClassExampleData classData = classToExData.get(encodedClassIRI);
+        PropertyExampleData propertyData = classData.propToExData.get(encodedProperty);
+        Set<PropertyValue> encodedValues = null;
+
+        // Check if there property exists in the class
+        if (propertyData != null){
+            encodedValues = propertyData.encodedValues;
+        }
+
+        Set<String> examples = new HashSet<>();
+
+        // Check if there is any example-value for the property
+        if (encodedValues != null) {
+            for (PropertyValue enVal : encodedValues) {
+                // Adding example-value
+                StringBuilder ex = new StringBuilder(stringEncoder.decode(enVal.rawValue));
+                // Adding label
+                String label;
+                if (IRItoLabel.containsKey(enVal.actualValue)) {
+                    label = "(" + stringEncoder.decode(IRItoLabel.get(enVal.actualValue)) + ")";
+                } else {
+                    label = "(" + DEFAULT_LABEL + ")";
+                }
+                ex.append(label);
+
+                examples.add(ex.toString());
+            }
+        }
+
+        return examples;
+    }
+    /*====================================================================================================*/
+
+
+
+
+
+
+
+
+
+    /*===================================Classi di supporto====================================*/
+    /**
+     * Store all the data of a specific class.
+     */
+    private class ClassExampleData{
+        // For each example-node (of this class) we store a bunch of data
+        Map<Node,ExampleNodeData> exNodeToExData;
+        // For each property (of this class) we store a bunch of data
+        Map<Integer,PropertyExampleData> propToExData;
+        // Total number of node (of this class) seen so far. Useful for reservoir sampling
+        int totalNodeCount;
+
+        protected ClassExampleData(){
+            exNodeToExData = new HashMap<>(EXAMPLES_FOR_CLASS);
+            propToExData = new HashMap<>();
+            totalNodeCount = 0;
+        }
+
+        /**
+         * Add {@code exNode} to the example-nodes and associate to it data {@code nodeData}
+         * @param exNode Example-node
+         * @param nodeData Data of {@code exNode}
+         */
+        protected void addExampleNode(Node exNode, ExampleNodeData nodeData) {
+            exNodeToExData.put(exNode, nodeData);
+            // Keeping track of total number of nodes seen so far
+            incrementTotalNodeCount();
+        }
+
+        /**
+         * (useful for reservoir sampling)<br>
+         * Delete node of index {@code candidateIndex} from example-nodes set
+         * @param candidateIndex Index of the example-node to delete
+         */
+        public void removeExampleNode(int candidateIndex) {
+            Node candidateNode = (Node) exNodeToExData.keySet().toArray()[candidateIndex];
+            exNodeToExData.remove(candidateNode);
+        }
+
+        /**
+         * Add the example-value ({@code encodedActualValue}, {@code encodedRawValue}) to the property {@code encodedProperty} example-values
+         * @param encodedProperty Encoded property
+         * @param encodedActualValue Encoded non-raw value
+         * @param encodedRawValue Encoded raw value
+         */
+        protected void addPropertyExample(Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+            // If it's the first time we see this property in this class, initialize property data
+            if (propToExData.get(encodedProperty) == null){
+                propToExData.put(encodedProperty, new PropertyExampleData());
+            }
+
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.addValue(encodedActualValue, encodedRawValue);
+        }
+
+        /**
+         * (useful for reservoir sampling)<br>
+         * Delete value of index {@code candidateIndex} from {@code encodedProperty} example-values set.
+         *
+         * @param candidateIndex  Index of the example-value to delete
+         * @param encodedProperty Encoded property
+         */
+        public void removePropertyValue(int candidateIndex, Integer encodedProperty) {
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.removeValue(candidateIndex);
+        }
+
+        /**
+         * @param encodedProperty Encoded property
+         * @return The total number of values seen so far for the property {@code encodedProperty} in this class
+         */
+        protected int propertyValuesCount(Integer encodedProperty){
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+
+            if (propertyData == null)
+                return 0;
+
+            return propertyData.valuesCount();
+        }
+
+        /**
+         * @param encodedProperty Encoded property
+         * @param encodedActualValue Encoded non-raw value
+         * @param encodedRawValue Encoded raw value
+         * @return {@code true} if the value ({@code encodedActualValue}, {@code encodedRawValue}) is stored as example-value for property {@code encodedProperty}<br>
+         *          {@code false} otherwise
+         */
+        protected boolean propertyContainsValue(Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            return propertyData.containsValue(encodedActualValue, encodedRawValue);
+        }
+
+        /**
+         * Set the property {@code encodedProperty} min count to the given value
+         * @param encodedProperty Encoded property
+         * @param minCount Given value
+         */
+        protected void setPropertyMinCount(Integer encodedProperty, int minCount){
+            // Set the property minCount in the class
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setMinCount(minCount);
+            // Set the property minCount in all example-nodes of the class
+            exNodeToExData.forEach((node, nodeData) ->{
+                // An example-node may not have all properties
+                if (nodeData.hasProperty(encodedProperty))
+                    nodeData.setPropertyMinCount(encodedProperty, minCount);
+            });
+        }
+
+        /**
+         * Set the property {@code encodedProperty} max count to the given value
+         * @param encodedProperty Encoded property
+         * @param maxCount Given value
+         */
+        protected void setPropertyMaxCount(Integer encodedProperty, int maxCount){
+            // Set the property maxCount in the class
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setMaxCount(maxCount);
+            // Set the property maxCount in all example-nodes of the class
+            exNodeToExData.forEach((node, nodeData) ->{
+                // An example-node may not have all properties
+                if (nodeData.hasProperty(encodedProperty))
+                    nodeData.setPropertyMaxCount(encodedProperty, maxCount);
+            });
+        }
+
+        /**
+         * Set the property type of property {@code encodedProperty} to the given type
+         * @param encodedProperty Encoded property
+         * @param encodedPropertyType Given property type
+         */
+        protected void setPropertyType(Integer encodedProperty, Integer encodedPropertyType) {
+            if (propToExData.get(encodedProperty) == null)
+                propToExData.put(encodedProperty, new PropertyExampleData());
+
+            // Set the propertyType in the class
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setPropertyType(encodedPropertyType);
+            // Set the property type in all example-nodes of the class
+            exNodeToExData.forEach((node, nodeData) ->{
+                // An example-node may not have all properties
+                if (nodeData.hasProperty(encodedProperty))
+                    nodeData.setPropertyType(encodedProperty, encodedPropertyType);
+            });
+        }
+
+        /**
+         * Set the isLiteral value of property {@code encodedProperty} to the given value
+         * @param encodedProperty Encoded property
+         * @param isLiteral Given value
+         */
+        protected void setPropertyIsLiteral(Integer encodedProperty, boolean isLiteral) {
+            // Set the isLiteralType of property in the class
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setIsLiteral(isLiteral);
+            // Set the isLiteralType in all example-nodes of the class
+            exNodeToExData.forEach((node, nodeData) ->{
+                // An example-node may not have all properties
+                if (nodeData.hasProperty(encodedProperty))
+                    nodeData.setPropertyIsLiteral(encodedProperty, isLiteral);
+            });
+        }
+
+        /**
+         * @param encodedProperty Encoded property
+         * @return {@code true} if {@code encodedProperty} is a literal type.<br>
+         *          {@code false} otherwise
+         */
+        protected boolean isPropertyLiteralType(Integer encodedProperty) {
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            return propertyData.isLiteralType();
+        }
+
+        /**
+         * @return Total number of nodes(of this class) seen so far
+         */
+        protected int getTotalNodeCount(){
+            return totalNodeCount;
+        }
+
+        /**
+         * Increment the total number of nodes(of this class) seen so far
+         */
+        protected void incrementTotalNodeCount(){
+            totalNodeCount++;
+        }
+
+        /**
+         * @param encodedProperty Encoded property
+         * @return Total number of nodes(of this class) seen so far
+         */
+        protected int getPropertyTotalValueCount(Integer encodedProperty){
+            return propToExData.get(encodedProperty).getTotalValueCount();
+        }
+
+        /**
+         * Increment the total number of values seen so far for property {@code encodedProperty}
+         * @param encodedProperty Encoded property
+         */
+        protected void incrementPropertyTotaleValueCount(Integer encodedProperty){
+            propToExData.get(encodedProperty).incrementTotalValueCount();
+        }
+    }
+
+
+    /**
+     * Store all data of a specific example-node
+     */
+    private class ExampleNodeData{
+        // For each property of the example-node we save a bunch of data
+        Map<Integer,PropertyExampleData> propToExData;
+
+        protected ExampleNodeData(){
+            propToExData = new HashMap<>();
+        }
+
+        /**
+         * Add value ({@code encodedActualValue}, {@code encodedRawValue}) to property {@code encodedProperty} example-values
+         * @param encodedProperty Encoded property
+         * @param encodedActualValue Encoded non-raw value to add
+         * @param encodedRawValue Encoded raw value to add
+         */
+        protected void addPropertyValue(Integer encodedProperty, Integer encodedActualValue, Integer encodedRawValue){
+            // If it's the first time we see the property for this node, add the property to the node
+            if (!propToExData.containsKey(encodedProperty)){
+                propToExData.put(encodedProperty, new PropertyExampleData());
+            }
+
+            PropertyExampleData propData = propToExData.get(encodedProperty);
+            propData.addValue(encodedActualValue, encodedRawValue);
+        }
+
+        /**
+         * @param encodedProperty Encoded property
+         * @return {@code true} if this node has the property {@code encodedProperty}
+         */
+        protected boolean hasProperty(Integer encodedProperty){
+            return propToExData.containsKey(encodedProperty);
+        }
+
+        /**
+         * Set the property {@code encodedProperty} min count to the given value
+         * @param encodedProperty Encoded property
+         * @param minCount Given value
+         */
+        protected void setPropertyMinCount(Integer encodedProperty, int minCount){
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setMinCount(minCount);
+        }
+
+        /**
+         * Set the property {@code encodedProperty} max count to the given value
+         * @param encodedProperty Encoded property
+         * @param maxCount Given value
+         */
+        protected void setPropertyMaxCount(Integer encodedProperty, int maxCount){
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setMaxCount(maxCount);
+        }
+
+        /**
+         * Set the property type of property {@code encodedProperty} to the given type
+         * @param encodedProperty Encoded property
+         * @param encodedPropertyType Given type
+         */
+        public void setPropertyType(Integer encodedProperty, Integer encodedPropertyType) {
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setPropertyType(encodedPropertyType);
+        }
+
+        /**
+         * Set the isLiteral value of property {@code encodedProperty} to the given value
+         * @param encodedProperty Encoded property
+         * @param isLiteral Given value
+         */
+        public void setPropertyIsLiteral(Integer encodedProperty, boolean isLiteral) {
+            PropertyExampleData propertyData = propToExData.get(encodedProperty);
+            propertyData.setIsLiteral(isLiteral);
+        }
+    }
+
+
+    /**
+     * Store all data of a property OF A SPECIFIC CLASS. So, all data stored in a object of this type refers to a specific couple (class, property)
+     */
+    private class PropertyExampleData{
+        // Set of example-values(encoded) of the property
+        Set<PropertyValue> encodedValues;
+        // Min and Max cardinal constraints
+        int maxCount;
+        int minCount;
+        // Property type(encoded)
+        Integer encodedPropertyType;
+        // TRUE: the property contains literal values. FALSE: the property contains IRIs
+        boolean isLiteralType;
+        // Total number of values seen so far (useful for reservoir sampling)
+        int totalValueCount;
+
+        protected PropertyExampleData(){
+            encodedValues = new HashSet<>(EXAMPLES_FOR_PROPERTY);
+            maxCount = DEFAULT_MAX;
+            minCount = DEFAULT_MIN;
+            encodedPropertyType = DEFAULT_ENCODED_PROP_TYPE;
+            isLiteralType = true;
+            totalValueCount = 0;
+        }
+
+        /**
+         * Add the value ({@code encodedActualValue}, {@code encodedRawValue}) to the example-values
+         * @param encodedActualValue Encoded non-raw value
+         * @param encodedRawValue Encoded raw value
+         */
+        protected void addValue(Integer encodedActualValue, Integer encodedRawValue){
+            PropertyValue completeValue = new PropertyValue(encodedActualValue, encodedRawValue);
+            encodedValues.add(completeValue);
+            // Keeping track of total number of values seen so far
+            incrementTotalValueCount();
+        }
+
+        /**
+         * (useful for reservoir sampling)
+         * Delete the value of index {@code candidateIndex} from the example-values set
+         *
+         * @param candidateIndex Index of the example-value to delete
+         */
+        public void removeValue(int candidateIndex) {
+            PropertyValue candidateEncodedValue = (PropertyValue) encodedValues.toArray()[candidateIndex];
+            encodedValues.remove(candidateEncodedValue);
+        }
+
+        /**
+         * @return The number of example-values stored for this property
+         */
+        protected int valuesCount(){
+            return encodedValues.size();
+        }
+
+        /**
+         * @param encodedActualValue Encoded non-raw value
+         * @param encodedRawValue Encoded raw value<
+         * @return {@code true} if value ({@code encodedActualValue}, {@code encodedRawValue}) is in example-values set.<br>
+         *          {@code false} otherwise
+         */
+        protected boolean containsValue(Integer encodedActualValue, Integer encodedRawValue){
+            PropertyValue targetValue = new PropertyValue(encodedActualValue,encodedRawValue);
+            return encodedValues.contains(targetValue);
+        }
+
+        /**
+         * Set the property min count to the given value
+         * @param minCount Given value
+         */
+        protected void setMinCount(int minCount){
+            this.minCount=minCount;
+        }
+
+        /**
+         * Set the property max count to the given value
+         * @param maxCount Given value
+         */
+        protected void setMaxCount(int maxCount){
+            this.maxCount=maxCount;
+        }
+
+        /**
+         * Set the property type to the given type
+         * @param encodedPropertyType Given type
+         */
+        protected void setPropertyType(Integer encodedPropertyType){
+            this.encodedPropertyType = encodedPropertyType;
+        }
+
+        /**
+         * @return The (encoded)property type of this property
+         */
+        protected Integer getPropertyType(){
+            return encodedPropertyType;
+        }
+
+        /**
+         * Set the property isLiteral value to the given value
+         * @param isLiteral Given value
+         */
+        protected void setIsLiteral(boolean isLiteral) {
+            this.isLiteralType = isLiteral;
+        }
+
+        /**
+         * @return {@code true} if property is literal type.<br>
+         *          {@code false} otherwise
+         */
+        protected boolean isLiteralType() {
+            return isLiteralType;
+        }
+
+        /**
+         * Increment the total number of values seen so far for this property
+         */
+        protected void incrementTotalValueCount(){
+            totalValueCount++;
+        }
+
+        /**
+         * @return The total number of values seen so far for this property
+         */
+        protected int getTotalValueCount(){
+            return totalValueCount;
+        }
+    }
+
+    /**
+     * Contains one value of a property. The value is stored both in raw and non-raw form. <br>
+     * Store raw-values is useful for creating literals of the correct type. <br>
+     * EXAMPLES: <br>
+     * Valore                                               ||   actualValue                                         ||   rawValue
+     * <http://www.Department0.University0.edu/Course20>    ||   'http://www.Department0.University0.edu/Course20'   ||   '<http://www.Department0.University0.edu/Course20>'
+     * "30"^^<http://www.w3.org/2001/XMLSchema#int>         ||   '30'                                                ||   '"30"^^<http://www.w3.org/2001/XMLSchema#int>'
+     */
+    private class PropertyValue{
+        /** Non-raw property value **/
+        Integer actualValue;
+        /** Raw property value**/
+        Integer rawValue;
+
+        PropertyValue(Integer actualValue, Integer rawValue){
+            this.actualValue = actualValue;
+            this.rawValue = rawValue;
+        }
+
+
+        @Override
+        // Important to store object of this type in HashSets
+        public boolean equals(Object obj){
+            if (this == obj)
+                return true;
+            if (obj == null || getClass() != obj.getClass())
+                return false;
+            PropertyValue that = (PropertyValue) obj;
+            return actualValue.equals(that.actualValue) && rawValue.equals(that.rawValue);
+        }
+
+        @Override
+        // Important to store object of this type in HashSets
+        public int hashCode() {
+            return actualValue.hashCode() ^ rawValue.hashCode();
+        }
+
+    }
+    /*=====================================================================================================*/
+}

--- a/src/main/java/cs/qse/common/Utility.java
+++ b/src/main/java/cs/qse/common/Utility.java
@@ -182,4 +182,5 @@ public class Utility {
         }
         return conn;
     }
+
 }

--- a/src/main/java/cs/qse/filebased/Parser.java
+++ b/src/main/java/cs/qse/filebased/Parser.java
@@ -13,6 +13,7 @@ import org.semanticweb.yars.nx.Node;
 import org.semanticweb.yars.nx.parser.NxParser;
 import org.semanticweb.yars.nx.parser.ParseException;
 
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -34,18 +35,29 @@ public class Parser {
     // N = number of distinct nodes in the graph
     // T = number of distinct types
     // P = number of distinct predicates
-    
+
     Map<Node, EntityData> entityDataHashMap; // Size == N For every entity we save a number of summary information
     Map<Integer, Integer> classEntityCount; // Size == T
     Map<Integer, Map<Integer, Set<Integer>>> classToPropWithObjTypes; // Size O(T*P*T)
     Map<Tuple3<Integer, Integer, Integer>, SupportConfidence> shapeTripletSupport; // Size O(T*P*T) For every unique <class,property,objectType> tuples, we save their support and confidence
-    
+
+    // OBJECTS FOR EXAMPLE CREATION
+    // If true, add examples to the extracted shapes
+    protected boolean addExamples;
+    // List of all predicates used to identify labels
+    protected List<String> labelPredicates;
+    // Random number generator (for Reservoir Sampling)
+    protected Random random;
+    // This object contains all data and methods used for examples creation
+    protected ExampleManager exampleManager;
+
+
     public Parser() {}
     
     /**
      * ============================================= Constructor ========================================
      */
-    public Parser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate) {
+    public Parser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate, boolean addExamples, List<String> labelPredicates) {
         this.rdfFilePath = filePath;
         this.expectedNumberOfClasses = expNoOfClasses;
         this.expNoOfInstances = expNoOfInstances;
@@ -54,6 +66,10 @@ public class Parser {
         this.classToPropWithObjTypes = new HashMap<>((int) ((expectedNumberOfClasses) / 0.75 + 1));
         this.entityDataHashMap = new HashMap<>((int) ((expNoOfInstances) / 0.75 + 1));
         this.stringEncoder = new StringEncoder();
+        exampleManager = new ExampleManager(stringEncoder);
+        this.addExamples = addExamples;
+        this.labelPredicates = labelPredicates;
+        random = new Random();
     }
     
     /**
@@ -62,13 +78,18 @@ public class Parser {
     public void run() {
         entityExtraction();
         entityConstraintsExtraction();
+        // Store the labels only if example creation is required
+        if (addExamples){
+            storeLabels();
+        }
         computeSupportConfidence();
         extractSHACLShapes(true, Main.qseFromSpecificClasses);
         //assignCardinalityConstraints();
         Utility.writeClassFrequencyInFile(classEntityCount, stringEncoder);
         System.out.println("STATS: \n\t" + "No. of Classes: " + classEntityCount.size());
     }
-    
+
+
     /**
      * ============================================= Phase 1: Entity Extraction ========================================
      * Streaming over RDF (NT Format) triples <s,p,o> line by line to extract set of entity types and frequency of each entity.
@@ -92,11 +113,31 @@ public class Parser {
                         entityData.getClassTypes().add(objID);
                         entityDataHashMap.put(nodes[0], entityData);
                         classEntityCount.merge(objID, 1, Integer::sum);
+
+                        if (addExamples) {
+                            Integer encodedClassIRI = objID;
+                            Node exampleNode = nodes[0];
+                            // ADDING EXAMPLE NODES USING RESERVOIR SAMPLING
+                            // If maximum example-node capacity has not been reached, add the current node to the example-nodes
+                            if (exampleManager.exampleNodeCount(encodedClassIRI) < ExampleManager.EXAMPLES_FOR_CLASS) {
+                                exampleManager.addExampleNode(encodedClassIRI, exampleNode);
+                            }
+                            // Otherwise, replace an example-node with the current node (the probability of this to happen is EXAMPLES_FOR_CLASS/totalClassNodeCount)
+                            else {
+                                int candidateIndex = random.nextInt(exampleManager.totalNodeCount(encodedClassIRI));
+                                exampleManager.replaceExampleNode(candidateIndex, encodedClassIRI, exampleNode);
+                            }
+                        }
                     }
                 } catch (ParseException e) {
                     e.printStackTrace();
                 }
             });
+
+            if (addExamples) {
+                // List all the example-nodes
+                exampleManager.listExampleNodes();
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -110,7 +151,6 @@ public class Parser {
      * to compute the support and confidence of each candidate shape.
      * =================================================================================================================
      */
-    
     protected void entityConstraintsExtraction() {
         StopWatch watch = new StopWatch();
         watch.start();
@@ -130,13 +170,112 @@ public class Parser {
                     // object is an instance or entity of some class e.g., :Paris is an instance of :City & :Capital
                     if (objectType.equals("IRI")) {
                         objTypesIDs = parseIriTypeObject(objTypesIDs, prop2objTypeTuples, nodes, entityNode, propID);
+
+                        if (addExamples) {
+                            // For each class of the subject node, set the property type to NON-literal
+                            Set<Integer> classIDs = entityDataHashMap.get(entityNode).getClassTypes();
+                            classIDs.forEach(encodedClassIRI -> {
+                                exampleManager.setPropertyType(encodedClassIRI, propID, stringEncoder.encode(objectType));
+                                exampleManager.setPropertyIsLiteral(encodedClassIRI, propID, false);
+                            });
+                        }
                     }
                     // Object is of type literal, e.g., xsd:String, xsd:Integer, etc.
                     else {
                         parseLiteralTypeObject(objTypesIDs, entityNode, objectType, propID);
+
+                        if (addExamples) {
+                            // For each class of the subject node, set the property type to literal
+                            Set<Integer> classIDs = entityDataHashMap.get(entityNode).getClassTypes();
+                            classIDs.forEach(encodedClassIRI -> {
+                                exampleManager.setPropertyType(encodedClassIRI, propID, stringEncoder.encode(objectType));
+                                exampleManager.setPropertyIsLiteral(encodedClassIRI, propID, true);
+                            });
+                        }
                     }
                     // for each type (class) of current entity -> append the property and object type in classToPropWithObjTypes HashMap
                     updateClassToPropWithObjTypesMap(objTypesIDs, entityNode, propID);
+
+
+                    if (addExamples) {
+                        String property = nodes[1].getLabel();
+                        String actualValue = nodes[2].getLabel();
+                        String rawValue = nodes[2].toString();
+                        Integer encodedProperty = stringEncoder.encode(property);
+                        Integer encodedActualValue = stringEncoder.encode(actualValue);
+                        Integer encodedRawValue = stringEncoder.encode(rawValue);
+
+                        // ADDING VALUES TO PROPERTIES OF EXAMPLE-NODES
+                        // If the current node(subject) is an example-node, store his data
+                        if (exampleManager.isExampleNode(entityNode)) {
+                            exampleManager.addNodeData(entityNode, encodedProperty, encodedActualValue, encodedRawValue);
+                        }
+
+                        // ADDING EXAMPLE VALUES TO PROPERTIES WITH RESERVOIR SAMPLING
+                        // For each class of the current node(subject), add the property value as an example value for that class
+                        Set<Integer> classIDs = entityDataHashMap.get(entityNode).getClassTypes();
+                        classIDs.forEach(encodedClassIRI -> {
+                            // If the maximum capacity of example-values has not been reached, add the current property value to the example-values
+                            if (exampleManager.propertyValuesCount(encodedClassIRI, encodedProperty) < ExampleManager.EXAMPLES_FOR_PROPERTY) {
+                                exampleManager.addPropertyExample(encodedClassIRI, encodedProperty, encodedActualValue, encodedRawValue);
+                            }
+                            // Otherwise, replace an example-value of the property with the current value (the probability of this to happen is EXAMPLES_FOR_PROPERTY/totalValuesCount)
+                            else {
+                                int candidateIndex = random.nextInt(exampleManager.totalPropertyValueCount(encodedClassIRI, encodedProperty));
+                                exampleManager.replacePropertyExample(candidateIndex, encodedClassIRI, encodedProperty, encodedActualValue, encodedRawValue);
+                            }
+                        });
+                    }
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                }
+            });
+
+            if (addExamples) {
+                // List all the example-values of all properties
+                exampleManager.listPropertiesValues();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        watch.stop();
+        Utils.logTime("secondPhase", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
+    }
+
+
+    /**
+     * Iterating a third time on the RDF to store the labels
+     * Given the triple (s,p,o) where s=IRI, p=rdf:label, o=label, store the label for the subject s
+     * N.B. ONLY labels useful in example creation will be stored. So, a label is stored only if the subject is:
+     *  -a class, or
+     *  -a property, or
+     *  -an example-node, or
+     *  -a value stored as example-value of a property
+     */
+    protected void storeLabels() {
+        System.out.println("Storing labels");
+        StopWatch watch = new StopWatch();
+        watch.start();
+        try {
+            Files.lines(Path.of(rdfFilePath)).forEach(line -> {
+                try {
+                    Node[] nodes = NxParser.parseNodes(line); // Get [S,P,O] as Node from triple
+                    if (labelPredicates.contains(nodes[1].toString())) { // Check if predicate is rdf:label or equivalent
+                        Node subject = nodes[0];
+                        Node object = nodes[2];
+                        Integer encodedSubject = stringEncoder.encode(subject.getLabel());
+                        Integer encodedRawSubject = stringEncoder.encode(subject.toString());
+                        Integer encodedLabel = stringEncoder.encode(object.getLabel());
+
+                        /* Check the type of the label subject:
+                            if the subject is a class, a property(predicate), an example-node or a value stored as example-value,
+                            then store the label
+                         */
+                        if (exampleManager.isClass(encodedSubject) || exampleManager.isProperty(encodedSubject) || exampleManager.isExampleNode(subject) ||exampleManager.isPropertyValue(encodedSubject,encodedRawSubject)){
+                            exampleManager.storeLabel(encodedSubject, encodedLabel);
+                        }
+                        // Otherwise DON'T store the label
+                    }
                 } catch (ParseException e) {
                     e.printStackTrace();
                 }
@@ -145,7 +284,7 @@ public class Parser {
             e.printStackTrace();
         }
         watch.stop();
-        Utils.logTime("secondPhase", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
+        Utils.logTime("Label storing", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
     }
     
     /**
@@ -179,8 +318,8 @@ public class Parser {
         //====================== Enable shapes extraction for specific classes ======================
         if (qseFromSpecificClasses)
             classToPropWithObjTypes = Utility.extractShapesForSpecificClasses(classToPropWithObjTypes, classEntityCount, stringEncoder);
-        
-        se.constructDefaultShapes(classToPropWithObjTypes); // SHAPES without performing pruning based on confidence and support thresholds
+
+        se.constructDefaultShapes(classToPropWithObjTypes, exampleManager); // SHAPES without performing pruning based on confidence and support thresholds
         if (performPruning) {
             StopWatch watchForPruning = new StopWatch();
             watchForPruning.start();
@@ -188,7 +327,7 @@ public class Parser {
                 supportRange.forEach(supp -> {
                     StopWatch innerWatch = new StopWatch();
                     innerWatch.start();
-                    se.constructPrunedShapes(classToPropWithObjTypes, conf, supp);
+                    se.constructPrunedShapes(classToPropWithObjTypes, exampleManager, conf, supp);
                     innerWatch.stop();
                     Utils.logTime(conf + "_" + supp + "", TimeUnit.MILLISECONDS.toSeconds(innerWatch.getTime()), TimeUnit.MILLISECONDS.toMinutes(innerWatch.getTime()));
                 });
@@ -305,4 +444,6 @@ public class Parser {
         watch.stop();
         Utils.logTime("assignCardinalityConstraints", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
     }
+
+
 }

--- a/src/main/java/cs/qse/filebased/RandomSamplingParser.java
+++ b/src/main/java/cs/qse/filebased/RandomSamplingParser.java
@@ -19,8 +19,8 @@ public class RandomSamplingParser extends Parser {
     public int randomSamplingThreshold; // Random sampling threshold like 10 means: 10%
     Map<Integer, Integer> sampledClassEntityCount; // Size == T (number of distinct types) having count of entities sampled randomly based on defined threshold
     
-    public RandomSamplingParser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate, int entitySamplingThreshold) {
-        super(filePath, expNoOfClasses, expNoOfInstances, typePredicate);
+    public RandomSamplingParser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate, boolean addExamples, List<String> labelPredicates, int entitySamplingThreshold) {
+        super(filePath, expNoOfClasses, expNoOfInstances, typePredicate, addExamples, labelPredicates);
         this.sampledClassEntityCount = new HashMap<>((int) ((expectedNumberOfClasses) / 0.75 + 1));
         this.randomSamplingThreshold = entitySamplingThreshold;
     }

--- a/src/main/java/cs/qse/filebased/sampling/ReservoirSamplingParser.java
+++ b/src/main/java/cs/qse/filebased/sampling/ReservoirSamplingParser.java
@@ -1,10 +1,7 @@
 package cs.qse.filebased.sampling;
 
 import cs.Main;
-import cs.qse.common.EntityData;
-import cs.qse.common.ExperimentsUtil;
-import cs.qse.common.ShapesExtractor;
-import cs.qse.common.Utility;
+import cs.qse.common.*;
 import cs.qse.filebased.*;
 import cs.utils.Constants;
 import cs.utils.Tuple2;
@@ -49,7 +46,7 @@ public class ReservoirSamplingParser extends Parser {
     Map<Integer, Integer> propCount; // real count of *all (entire graph)* triples having predicate P   // |P| =  |< _, P , _ >| in G
     Map<Integer, Integer> sampledPropCount; // count of triples having predicate P across all entities in all reservoirs  |< _ , P , _ >| (the sampled entities)
     
-    public ReservoirSamplingParser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate, Integer entitySamplingThreshold) {
+    public ReservoirSamplingParser(String filePath, int expNoOfClasses, int expNoOfInstances, String typePredicate, boolean addExaples, List<String> labelPredicates, Integer entitySamplingThreshold) {
         this.rdfFilePath = filePath;
         this.expectedNumberOfClasses = expNoOfClasses;
         this.expNoOfInstances = expNoOfInstances;
@@ -63,6 +60,10 @@ public class ReservoirSamplingParser extends Parser {
         this.stringEncoder = new StringEncoder();
         this.nodeEncoder = new NodeEncoder();
         this.maxEntityThreshold = entitySamplingThreshold;
+        exampleManager = new ExampleManager(stringEncoder);
+        this.addExamples = addExaples;
+        this.labelPredicates = labelPredicates;
+        random = new Random();
     }
     
     public void run() {
@@ -73,6 +74,10 @@ public class ReservoirSamplingParser extends Parser {
     private void runParser() {
         dynamicNbReservoirSampling();
         entityConstraintsExtraction();
+        // Store the labels only if example creation is required
+        if(addExamples){
+            storeLabels();
+        }
         computeSupportConfidence();
         extractSHACLShapes(true, Main.qseFromSpecificClasses);
         Utility.writeClassFrequencyInFile(classEntityCount, stringEncoder);
@@ -101,6 +106,7 @@ public class ReservoirSamplingParser extends Parser {
                             srs.replace(random.nextInt(lineCounter.get()), nodes);
                         }
                         classEntityCount.merge(objID, 1, Integer::sum); // Get the real entity count for current class
+
                     }
                     lineCounter.getAndIncrement(); // increment the line counter
                 } catch (ParseException e) {
@@ -187,6 +193,30 @@ public class ReservoirSamplingParser extends Parser {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        if (addExamples) {
+            // Adding example-nodes for each class selecting only nodes already sampled(only nodes contained in [sampledEntitiesPerClass])
+            sampledEntitiesPerClass.forEach((encodedClassIRI, encodedNodes) -> {
+                encodedNodes.forEach(encodedNode -> {
+                    Node exampleNode = nodeEncoder.decode(encodedNode);
+
+                    // ADDING EXAMPLE NODES USING RESERVOIR SAMPLING
+                    // If maximum example-node capacity has not been reached, add the current node to the example-nodes
+                    if (exampleManager.exampleNodeCount(encodedClassIRI) < ExampleManager.EXAMPLES_FOR_CLASS) {
+                        exampleManager.addExampleNode(encodedClassIRI, exampleNode);
+                    }
+                    // Otherwise, replace an example-node with the current node (the probability of this to happen is EXAMPLES_FOR_CLASS/totalClassNodeCount)
+                    else {
+                        int candidateIndex = random.nextInt(exampleManager.totalNodeCount(encodedClassIRI));
+                        exampleManager.replaceExampleNode(candidateIndex, encodedClassIRI, exampleNode);
+                    }
+                });
+            });
+
+            // List all the example-nodes
+            exampleManager.listExampleNodes();
+        }
+
         watch.stop();
         Utils.logTime("firstPass:dynamicNbReservoirSampling", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
         Utils.logSamplingStats("dynamicNbReservoirSampling", samplingPercentage, minEntityThreshold, maxEntityThreshold, entityDataMapContainer.size());
@@ -228,12 +258,31 @@ public class ReservoirSamplingParser extends Parser {
                                     addEntityToPropertyConstraints(prop2objTypeTuples, subjID);
                                 }
                                 /*else { // If we do not have data this is an unlabelled IRI objTypes = Collections.emptySet(); }*/
-                                
+
+                                if (addExamples) {
+                                    // For each class of the subject node([encodedNode]), set the property type to NON-literal
+                                    Integer encodedNode = nodeEncoder.encode(nodes[0]);
+                                    Set<Integer> classIDs = entityDataMapContainer.get(encodedNode).getClassTypes();
+                                    classIDs.forEach(encodedClassIRI -> {
+                                        exampleManager.setPropertyType(encodedClassIRI, propID, stringEncoder.encode(objectType));
+                                        exampleManager.setPropertyIsLiteral(encodedClassIRI, propID, false);
+                                    });
+                                }
                             } else { // Object is of type literal, e.g., xsd:String, xsd:Integer, etc.
                                 int objID = stringEncoder.encode(objectType);
                                 objTypes.add(objID);
                                 prop2objTypeTuples = Collections.singleton(new Tuple2<>(propID, objID));
                                 addEntityToPropertyConstraints(prop2objTypeTuples, subjID);
+
+                                if (addExamples) {
+                                    // For each class of the subject node, set the property type to literal
+                                    Integer encodedNode = nodeEncoder.encode(nodes[0]);
+                                    Set<Integer> classIDs = entityDataMapContainer.get(encodedNode).getClassTypes();
+                                    classIDs.forEach(encodedClassIRI -> {
+                                        exampleManager.setPropertyType(encodedClassIRI, propID, stringEncoder.encode(objectType));
+                                        exampleManager.setPropertyIsLiteral(encodedClassIRI, propID, true);
+                                    });
+                                }
                             }
                             
                             EntityData entityData = entityDataMapContainer.get(subjID);
@@ -255,9 +304,91 @@ public class ReservoirSamplingParser extends Parser {
                                 }
                             }
                             sampledPropCount.merge(propID, 1, Integer::sum); // Get the
+
+                            if (addExamples) {
+                                Node targetNode = nodes[0];
+                                String property = nodes[1].getLabel();
+                                String actualValue = nodes[2].getLabel();
+                                String rawValue = nodes[2].toString();
+                                Integer encodedNode = nodeEncoder.getEncodedNode(targetNode);
+                                Integer encodedProperty = stringEncoder.encode(property);
+                                Integer encodedActualValue = stringEncoder.encode(actualValue);
+                                Integer encodedRawValue = stringEncoder.encode(rawValue);
+
+                                // ADDING VALUES TO PROPERTIES OF EXAMPLE-NODES
+                                // If the current node(subject) is an example-node, store his data
+                                if (exampleManager.isExampleNode(targetNode)) {
+                                    exampleManager.addNodeData(targetNode, encodedProperty, encodedActualValue, encodedRawValue);
+                                }
+
+                                // ADDING EXAMPLE VALUES TO PROPERTIES WITH RESERVOIR SAMPLING
+                                // For each class of the current node(subject), add the property value as an example value for that class
+                                Set<Integer> classIDs = entityDataMapContainer.get(encodedNode).getClassTypes();
+                                classIDs.forEach(encodedClassIRI -> {
+                                    // If the maximum capacity of example-values has not been reached, add the current property value to the example-values
+                                    if (exampleManager.propertyValuesCount(encodedClassIRI, encodedProperty) < ExampleManager.EXAMPLES_FOR_PROPERTY) {
+                                        exampleManager.addPropertyExample(encodedClassIRI, encodedProperty, encodedActualValue, encodedRawValue);
+                                    }
+                                    // Otherwise, replace an example-value of the property with the current value (the probability of this to happen is EXAMPLES_FOR_PROPERTY/totalValuesCount)
+                                    else {
+                                        int candidateIndex = random.nextInt(exampleManager.totalPropertyValueCount(encodedClassIRI, encodedProperty));
+                                        exampleManager.replacePropertyExample(candidateIndex, encodedClassIRI, encodedProperty, encodedActualValue, encodedRawValue);
+                                    }
+                                });
+                            }
                         } // if condition for presence of node in the reservoir ends here
                     }
-                    
+
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                }
+            });
+
+            if (addExamples) {
+                // List all the example-values of all properties
+                exampleManager.listPropertiesValues();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        watch.stop();
+        Utils.logTime("secondPass:cs.qse.filebased.sampling.ReservoirSampling", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
+    }
+
+
+    /**
+     * Iterating a third time on the RDF to store the labels
+     * Given the triple (s,p,o) where s=IRI, p=rdf:label, o=label, store the label for the subject s.
+     * N.B. ONLY labels useful in example creation will be stored. So, a label is stored only if the subject is:
+     *  -a class, or
+     *  -a property, or
+     *  -an example-node, or
+     *  -a value stored as example-value of a property
+     */
+    protected void storeLabels() {
+        System.out.println("Storing labels");
+        StopWatch watch = new StopWatch();
+        watch.start();
+        try {
+            Files.lines(Path.of(rdfFilePath)).forEach(line -> {
+                try {
+                    Node[] nodes = NxParser.parseNodes(line); // Get [S,P,O] as Node from triple
+                    if (labelPredicates.contains(nodes[1].toString())) { // Check if predicate is rdf:label or equivalent
+                        Node subject = nodes[0];
+                        Node object = nodes[2];
+                        Integer encodedSubject = stringEncoder.encode(subject.getLabel());
+                        Integer encodedRawSubject = stringEncoder.encode(subject.toString());
+                        Integer encodedLabel = stringEncoder.encode(object.getLabel());
+
+                        /* Check the type of the label subject:
+                            if the subject is a class, a property(predicate), an example-node or a value stored as example-value,
+                            then store the label
+                         */
+                        if (exampleManager.isClass(encodedSubject) || exampleManager.isProperty(encodedSubject) || exampleManager.isExampleNode(subject) ||exampleManager.isPropertyValue(encodedSubject, encodedRawSubject)){
+                            exampleManager.storeLabel(encodedSubject, encodedLabel);
+                        }
+                        // Otherwise DON'T store the label
+                    }
                 } catch (ParseException e) {
                     e.printStackTrace();
                 }
@@ -266,9 +397,10 @@ public class ReservoirSamplingParser extends Parser {
             e.printStackTrace();
         }
         watch.stop();
-        Utils.logTime("secondPass:cs.qse.filebased.sampling.ReservoirSampling", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
+        Utils.logTime("Label storing", TimeUnit.MILLISECONDS.toSeconds(watch.getTime()), TimeUnit.MILLISECONDS.toMinutes(watch.getTime()));
     }
-    
+
+
     //A utility method to add property constraints of each entity in the 2nd pass
     private void addEntityToPropertyConstraints(Set<Tuple2<Integer, Integer>> prop2objTypeTuples, Integer subject) {
         EntityData currentEntityData = entityDataMapContainer.get(subject);
@@ -312,7 +444,7 @@ public class ReservoirSamplingParser extends Parser {
         //====================== Enable shapes extraction for specific classes ======================
         if (qseFromSpecificClasses)
             classToPropWithObjTypes = Utility.extractShapesForSpecificClasses(classToPropWithObjTypes, classEntityCount, stringEncoder);
-        se.constructDefaultShapes(classToPropWithObjTypes); // SHAPES without performing pruning based on confidence and support thresholds
+        se.constructDefaultShapes(classToPropWithObjTypes, exampleManager); // SHAPES without performing pruning based on confidence and support thresholds
         se.setPropCount(propCount);
         se.setSampledPropCount(sampledPropCount);
         se.setSampledEntitiesPerClass(sampledEntitiesPerClass);
@@ -322,7 +454,7 @@ public class ReservoirSamplingParser extends Parser {
             watchForPruning.start();
             ExperimentsUtil.getSupportConfRange().forEach((conf, supportRange) -> {
                 supportRange.forEach(supp -> {
-                    se.constructPrunedShapes(classToPropWithObjTypes, conf, supp);
+                    se.constructPrunedShapes(classToPropWithObjTypes, exampleManager, conf, supp);
                 });
             });
             methodName = "extractSHACLShapes:cs.qse.filebased.sampling.ReservoirSampling";

--- a/src/main/java/cs/qse/querybased/nonsampling/QbParser.java
+++ b/src/main/java/cs/qse/querybased/nonsampling/QbParser.java
@@ -1,6 +1,7 @@
 package cs.qse.querybased.nonsampling;
 
 import cs.Main;
+import cs.qse.common.ExampleManager;
 import cs.qse.common.ExperimentsUtil;
 import cs.qse.common.Utility;
 import cs.qse.common.ShapesExtractor;
@@ -185,8 +186,8 @@ public class QbParser {
         String methodName = "extractSHACLShapes:No Pruning";
         ShapesExtractor se = new ShapesExtractor(stringEncoder, shapeTripletSupport, classEntityCount, instantiationProperty);
         //se.setPropWithClassesHavingMaxCountOne(statsComputer.getPropWithClassesHavingMaxCountOne());
-        
-        se.constructDefaultShapes(classToPropWithObjTypes); // SHAPES without performing pruning based on confidence and support thresholds
+        /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+        se.constructDefaultShapes(classToPropWithObjTypes,new ExampleManager(stringEncoder)); // SHAPES without performing pruning based on confidence and support thresholds
         if (performPruning) {
             StopWatch watchForPruning = new StopWatch();
             watchForPruning.start();
@@ -194,7 +195,8 @@ public class QbParser {
                 supportRange.forEach(supp -> {
                     StopWatch innerWatch = new StopWatch();
                     innerWatch.start();
-                    se.constructPrunedShapes(classToPropWithObjTypes, conf, supp);
+                    /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+                    se.constructPrunedShapes(classToPropWithObjTypes, new ExampleManager(stringEncoder), conf, supp);
                     innerWatch.stop();
                     Utils.logTime(conf + "_" + supp + "", TimeUnit.MILLISECONDS.toSeconds(innerWatch.getTime()), TimeUnit.MILLISECONDS.toMinutes(innerWatch.getTime()));
                 });

--- a/src/main/java/cs/qse/querybased/sampling/QbSampling.java
+++ b/src/main/java/cs/qse/querybased/sampling/QbSampling.java
@@ -2,11 +2,8 @@ package cs.qse.querybased.sampling;
 
 import com.google.common.collect.Lists;
 import cs.Main;
-import cs.qse.common.EntityData;
-import cs.qse.common.Utility;
-import cs.qse.common.ShapesExtractor;
+import cs.qse.common.*;
 import cs.qse.filebased.SupportConfidence;
-import cs.qse.common.ExperimentsUtil;
 import cs.qse.filebased.sampling.DynamicNeighborBasedReservoirSampling;
 import cs.utils.*;
 import cs.qse.common.encoders.StringEncoder;
@@ -268,8 +265,8 @@ public class QbSampling {
         //====================== Enable shapes extraction for specific classes ======================
         if (qseFromSpecificClasses)
             classToPropWithObjTypes = Utility.extractShapesForSpecificClasses(classToPropWithObjTypes, classEntityCount, stringEncoder);
-        
-        se.constructDefaultShapes(classToPropWithObjTypes); // SHAPES without performing pruning based on confidence and support thresholds
+        /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+        se.constructDefaultShapes(classToPropWithObjTypes, new ExampleManager(stringEncoder)); // SHAPES without performing pruning based on confidence and support thresholds
         if (performPruning) {
             StopWatch watchForPruning = new StopWatch();
             watchForPruning.start();
@@ -277,7 +274,8 @@ public class QbSampling {
                 supportRange.forEach(supp -> {
                     StopWatch innerWatch = new StopWatch();
                     innerWatch.start();
-                    se.constructPrunedShapes(classToPropWithObjTypes, conf, supp);
+                    /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+                    se.constructPrunedShapes(classToPropWithObjTypes, new ExampleManager(stringEncoder), conf, supp);
                     innerWatch.stop();
                     Utils.logTime(conf + "_" + supp + "", TimeUnit.MILLISECONDS.toSeconds(innerWatch.getTime()), TimeUnit.MILLISECONDS.toMinutes(innerWatch.getTime()));
                 });

--- a/src/main/java/cs/qse/querybased/sampling/parallel/ParallelQbSampling.java
+++ b/src/main/java/cs/qse/querybased/sampling/parallel/ParallelQbSampling.java
@@ -3,6 +3,7 @@ package cs.qse.querybased.sampling.parallel;
 import com.google.common.collect.Lists;
 import cs.Main;
 import cs.qse.common.EntityData;
+import cs.qse.common.ExampleManager;
 import cs.qse.common.ExperimentsUtil;
 import cs.qse.common.encoders.ConcurrentStringEncoder;
 import cs.qse.common.encoders.NodeEncoder;
@@ -241,7 +242,8 @@ public class ParallelQbSampling {
         String methodName = "extractSHACLShapes:No Pruning";
         ShapesExtractor se = new ShapesExtractor(encoder, shapeTripletSupport, classEntityCount, typePredicate);
         //se.setPropWithClassesHavingMaxCountOne(statsComputer.getPropWithClassesHavingMaxCountOne());
-        se.constructDefaultShapes(classToPropWithObjTypes); // SHAPES without performing pruning based on confidence and support thresholds
+        /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+        se.constructDefaultShapes(classToPropWithObjTypes, new ExampleManager(encoder)); // SHAPES without performing pruning based on confidence and support thresholds
         
         if (performPruning) {
             StopWatch watchForPruning = new StopWatch();
@@ -250,7 +252,8 @@ public class ParallelQbSampling {
                 supportRange.forEach(supp -> {
                     StopWatch innerWatch = new StopWatch();
                     innerWatch.start();
-                    se.constructPrunedShapes(classToPropWithObjTypes, conf, supp);
+                    /* TODO currently this class doesn't collect data for example creation. We pass a new ExampleManager object only to compile correctly */
+                    se.constructPrunedShapes(classToPropWithObjTypes, new ExampleManager(encoder), conf, supp);
                     innerWatch.stop();
                     Utils.logTime(conf + "_" + supp + "", TimeUnit.MILLISECONDS.toSeconds(innerWatch.getTime()), TimeUnit.MILLISECONDS.toMinutes(innerWatch.getTime()));
                 });


### PR DESCRIPTION
Added examples to Shapes and PropertyShapes when using file-based parsers.
Example data storage and example creation are managed by the new class ExampleManager.

Restored complete configuration files (Main reads complete configuration files)

Added new properties to config files:
-add_examples: whether or not add examples to Shapes and PropertyShapes 
-label_properties: properties(predicates) used to recognize labels 
-example_IRI: IRI used as predicate to add examples in Shapes and PropertyShapes